### PR TITLE
Handle scanned PDF detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,10 +345,16 @@ Please note:
    ```
 
 > [!TIP]
-> 
+>
 > 1. The offline assets package name cannot be modified because the file list hash is encoded in the name.
 > 2. When using in production environments, it's recommended to pre-generate the assets package and include it with your application distribution.
 > 3. The package verification ensures that all required assets are intact and match their expected checksums.
+
+### Troubleshooting
+
+**"The document contains no paragraphs" error**
+
+If BabelDOC raises this error, no selectable text was detected in the PDF. The file might be a scanned document. Run the CLI with `--auto-enable-ocr-workaround` to automatically enable OCR processing.
 
 ## Background
 

--- a/babeldoc/format/pdf/high_level.py
+++ b/babeldoc/format/pdf/high_level.py
@@ -20,6 +20,7 @@ from pymupdf import Font
 from babeldoc import asynchronize
 from babeldoc.assets.assets import warmup
 from babeldoc.babeldoc_exception.BabelDOCException import ExtractTextError
+from babeldoc.babeldoc_exception.BabelDOCException import ScannedPDFError
 from babeldoc.const import CACHE_FOLDER
 from babeldoc.format.pdf.converter import TranslateConverter
 from babeldoc.format.pdf.document_il import il_version_1
@@ -779,21 +780,21 @@ def _do_translate_single(
     resfont = None
     doc_pdf2zh.save(temp_pdf_path)
 
-    # if not translation_config.skip_scanned_detection and DetectScannedFile(
-    #     translation_config
-    # ).fast_check(doc_pdf2zh):
-    #     if translation_config.auto_enable_ocr_workaround:
-    #         logger.warning(
-    #             "Fast scanned check hit, Turning on OCR workaround.",
-    #         )
-    #         translation_config.shared_context_cross_split_part.auto_enabled_ocr_workaround = True
-    #         translation_config.ocr_workaround = True
-    #         translation_config.skip_scanned_detection = True
-    #     else:
-    #         logger.warning(
-    #             "Fast scanned check hit, Please check the input PDF file.",
-    #         )
-    #         raise ScannedPDFError("Scanned PDF detected.")
+    if not translation_config.skip_scanned_detection and DetectScannedFile(
+        translation_config
+    ).fast_check(doc_pdf2zh):
+        if translation_config.auto_enable_ocr_workaround:
+            logger.warning(
+                "Fast scanned check hit, Turning on OCR workaround.",
+            )
+            translation_config.shared_context_cross_split_part.auto_enabled_ocr_workaround = True
+            translation_config.ocr_workaround = True
+            translation_config.skip_scanned_detection = True
+        else:
+            logger.warning(
+                "Fast scanned check hit, Please check the input PDF file.",
+            )
+            raise ScannedPDFError("Scanned PDF detected.")
 
     il_creater = ILCreater(translation_config)
     il_creater.mupdf = doc_pdf2zh
@@ -813,6 +814,16 @@ def _do_translate_single(
     del il_creater
     if translation_config.only_include_translated_page and not docs.page:
         return None
+
+    total_chars = 0
+    for page in docs.page:
+        total_chars += len(page.pdf_character)
+    if total_chars == 0:
+        logger.warning(
+            "No text detected in the PDF. It may be a scanned document. "
+            "Try running with '--auto-enable-ocr-workaround'.",
+        )
+        raise ExtractTextError("No text detected in the PDF.")
 
     if translation_config.debug:
         xml_converter.write_json(

--- a/babeldoc/format/pdf/translation_config.py
+++ b/babeldoc/format/pdf/translation_config.py
@@ -17,6 +17,15 @@ from babeldoc.translator.translator import BaseTranslator
 logger = logging.getLogger(__name__)
 
 
+class ConfigModel:
+    """Compatibility helper for old tests."""
+
+    @staticmethod
+    def _page_range_pattern() -> str:
+        """Return regex pattern for page range strings."""
+        return r"^([0-9]*-?[0-9]*\s*,\s*)*([0-9]*-?[0-9]*)\s*$"
+
+
 class WatermarkOutputMode(enum.Enum):
     Watermarked = "watermarked"
     NoWatermark = "no_watermark"


### PR DESCRIPTION
## Summary
- re-enable `fast_check` for scanned PDFs
- raise `ExtractTextError` early when no characters are detected
- mention missing-text error in README troubleshooting
- restore legacy `ConfigModel` for tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ac5f472c83209c7f9a70699c6520